### PR TITLE
Add support for HA energy

### DIFF
--- a/custom_components/sems2mqtt/__init__.py
+++ b/custom_components/sems2mqtt/__init__.py
@@ -244,6 +244,9 @@ async def async_setup(hass, config):
                 'value_template':'{{ value_json.etotal_kwh }}',
                 'icon':'mdi:flash',
                 'state_topic':'sems/sensors',
+                'state_class': "measurement",
+                'last_reset_value_template':'1970-01-01T00:00:00+00:00',
+                'last_reset_topic':'sems/sensors',
                 'unique_id':'sems_produced_total_sensor',
                     'device': create_device(data['type'])
             }


### PR DESCRIPTION
Add in values for state_class, last_reset_value and last_reset_topic to payload_etotal_kwh. 

Topic for last_reset_topic may need adjusting, but it works.