### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/sems2mqtt/__init__.py
+++ b/custom_components/sems2mqtt/__init__.py
@@ -245,8 +245,6 @@ async def async_setup(hass, config):
                 'icon':'mdi:flash',
                 'state_topic':'sems/sensors',
                 'state_class': "measurement",
-                'last_reset_value_template':'1970-01-01T00:00:00+00:00',
-                'last_reset_topic':'sems/sensors',
                 'device_class': 'energy',
                 'unique_id':'sems_produced_total_sensor',
                     'device': create_device(data['type'])


### PR DESCRIPTION
Deprecated since Home Assistant 2021.09: 

'last_reset_value_template':'1970-01-01T00:00:00+00:00',
'last_reset_topic':'sems/sensors',